### PR TITLE
fix showing feed on groups while wall still hidden

### DIFF
--- a/quiet-facebook.css
+++ b/quiet-facebook.css
@@ -16,7 +16,7 @@ div[id*="topnews"] {
 /* For Facebook 2020 redesign */
 div[data-pagelet="Stories"], /* Stories list */
 div[data-pagelet="VideoChatHomeUnit"], /* Rooms/video chat list */
-div[role="feed"], /* News feed */
+span#ssrb_feed_start+div[role="feed"], /* News feed */
 div[data-pagelet="RightRail"] > div:first-child > div:first-child /* Right rail's first section, which is an ad */
 {
   display: none !important;


### PR DESCRIPTION
This fixes #19, that wall in groups is also hidden.

Now the main wall is hidden, but the feed in groups is shown.