### PR TITLE
Update selector of 'RightRail' ads container

### DIFF
--- a/quiet-facebook.css
+++ b/quiet-facebook.css
@@ -17,7 +17,7 @@ div[id*="topnews"] {
 div[data-pagelet="Stories"], /* Stories list */
 div[data-pagelet="VideoChatHomeUnit"], /* Rooms/video chat list */
 span#ssrb_feed_start+div[role="feed"], /* News feed */
-div[data-pagelet="RightRail"] > div:first-child > div:first-child /* Right rail's first section, which is an ad */
+div[data-pagelet="RightRail"] > div:first-child > span:first-child /* Right rail's first section, which is an ad */
 {
   display: none !important;
 }


### PR DESCRIPTION
Hide Sponsored/ad column.
Looks like the selector introduced in https://github.com/maxfriedrich/quiet-facebook/pull/15 has changed