### PR TITLE
Removing reels feed

### DIFF
--- a/quiet-facebook.css
+++ b/quiet-facebook.css
@@ -1,15 +1,13 @@
-
 #pagelet_bookmark_nav, /* Left column: Bookmarks */
 div[id*="ticker"], /* Right column / Chat sidebar: news ticker */
 div[id*="pagelet_trending_tags_and_topics"], /* Right column: Trending tags and topics */
 div[id="stories_pagelet_rhc"], /* Right column: Stories */
-div[id="pagelet_ego_pane"] /* Right column: Ads */
-{
-  display: none !important;
+div[id="pagelet_ego_pane"] /* Right column: Ads */ {
+	display: none !important;
 }
 
 /* News feed - Needs visibility:hidden to prevent endless refreshing */
-div[id*="topnews"] { 
+div[id*="topnews"] {
 	visibility: hidden !important;
 }
 
@@ -17,7 +15,7 @@ div[id*="topnews"] {
 div[data-pagelet="Stories"], /* Stories list */
 div[data-pagelet="VideoChatHomeUnit"], /* Rooms/video chat list */
 span#ssrb_feed_start+div[role="feed"], /* News feed */
-div[data-pagelet="RightRail"] > div:first-child > span:first-child /* Right rail's first section, which is an ad */
-{
-  display: none !important;
+div[data-pagelet="RightRail"] > div:first-child > span:first-child, /* Right rail's first section, which is an ad */
+div[aria-label="panel Reels"] /*Reels feed*/ {
+	display: none !important;
 }


### PR DESCRIPTION
On the top are two buttons one for stories and the second for reels.
<img width="749" alt="Screenshot 2023-03-28 at 11 36 06" src="https://user-images.githubusercontent.com/64197585/228194838-a110aaef-55b4-4b72-9b4b-93e1b695b6b1.png">

When clicking on reels, I hide the reels feed
<img width="749" alt="Screenshot 2023-03-28 at 11 36 02" src="https://user-images.githubusercontent.com/64197585/228194842-27cf9b1d-eccf-47d3-bc1f-832415032b1f.png">
